### PR TITLE
Fix hot-reload not working

### DIFF
--- a/app.jl
+++ b/app.jl
@@ -1,16 +1,14 @@
-module App
 using PlotlyBase
 using GenieFramework
 using DataFrames
 using CSV
-include("./ui.jl")
 include("./constants.jl")
 include("./utils.jl")
 using .Constants: current_year, ScatterModel, LayoutModel, COLOR_SCALE_OPTIONS, ConfigType, MAPBOX_STYLES, DataModel, SampleDataModel
 using .Utils: scale_array, map_fields
 @genietools
 
-@app Model begin
+@app begin
   @in left_drawer_open = true
   @in filter_range::RangeData{Int} = RangeData(0:current_year)
   @in selected_size_feature::Union{Nothing,String} = nothing
@@ -152,7 +150,7 @@ using .Utils: scale_array, map_fields
         last_year = min_year + years_diff
       end
 
-      model.filter_range[] = RangeData(first_year:last_year)
+      filter_range = RangeData(first_year:last_year)
     end
 
     if animate
@@ -174,7 +172,8 @@ using .Utils: scale_array, map_fields
   @onbutton confirm_choose_sample_data begin
     show_sample_data_dialog = false
     df = CSV.read(choosen_sample_data, DataFrame) |> map_fields
-    model.data_input[] = DataTable(df, DataTableOptions(columns=map(col -> Column(col), names(df))))
+    data_input = DataTable(df, DataTableOptions(columns=map(col -> Column(col), names(df))))
+    @show "data loaded!"
   end
 
   @onbutton confirm_cancel_sample_data begin
@@ -183,12 +182,9 @@ using .Utils: scale_array, map_fields
 end
 
 
+@page("/", "ui.jl")
 
-route("/") do
-  global model = Model |> init |> handlers
-  return page(model, ui())
-end
-
+# this route should not work anymore since the global model is gone
 route("/", method=POST) do
   files = Genie.Requests.filespayload()
   f = first(files)
@@ -196,5 +192,5 @@ route("/", method=POST) do
   model.data_input[] = DataTable(df, DataTableOptions(columns=map(col -> Column(col), names(df))))
   return "Perfecto!"
 end
+    
 
-end

--- a/ui.jl
+++ b/ui.jl
@@ -1,60 +1,60 @@
-ui = () -> StippleUI.layout(
-  [
-    quasar(:header, toolbar(
-      [
-      btn(; dense=true, flat=true, round=true, icon="menu", @click("left_drawer_open = !left_drawer_open")),
-      toolbartitle("Genie Reactive Map")
-    ],
-    ),
-    ),
-    drawer(
-      Html.div(class="q-pa-md", [uploader(label="Upload Dataset", accept=".csv", method="POST", url="http://127.0.0.1:8000/", @on(:uploaded, :uploaded), style="width:100%"),
-        # item([itemsection(p("Marker color")), itemsection(input(type="color", var"v-model"=:selected_color, label="Color"))]),
-        item(Genie.Renderer.Html.select(:selected_color_feature, clearable=true, options=:features, label="Color based on", useinput=true)),
-        item(Genie.Renderer.Html.select(:color_scale, options=:color_scale_options, label="Color Scale", useinput=true, @showif("selected_color_feature"))),
-        item(Genie.Renderer.Html.select(:selected_size_feature, clearable=true, options=:features, label="Size based on", useinput=true)),
-        item(Genie.Renderer.Html.select(:mapbox_style, options=:mapbox_styles, label="Mapbox Style", useinput=true)),
-        item(btn("Show Data", color="primary", icon="view_list", style="font-weight: 600; text-transform: none;", @click("data_show_dialog = true")), @showif("plot_data.lon.length > 0")),
-        item(btn("Choose Sample Data", color="primary", icon="grid_view", style="background-color: rgb(239,239,239); font-weight: 600; text-transform: none;", flat=true, @click("show_sample_data_dialog = true"))),
-        Html.div(class="q-pa-md q-gutter-sm", [
-          StippleUI.dialog(:data_show_dialog, [
-              card([
-                Genie.Renderer.Html.table(title="View Data", :data_input; pagination=:data_pagination, style="height: 100%;")
-              ])
-            ], full__height=true, full__width=true)
-        ]),
-        Html.div(class="q-pa-md q-gutter-sm", [
-          StippleUI.dialog(:show_sample_data_dialog, [
-            card([
-              card_section(
-                quasar(:btn__toggle, v__model=:choosen_sample_data, options=:sample_data, style="flex-wrap: wrap")
-              ),
-              card_actions(
+StippleUI.layout(
+    [
+        quasar(:header, toolbar(
+            [
+            btn(; dense=true, flat=true, round=true, icon="menu", @click("left_drawer_open = !left_drawer_open")),
+            toolbartitle("Genie Reactive Map")
+        ],
+        ),
+        ),
+        drawer(
+            Html.div(class="q-pa-md", [uploader(label="Upload Dataset", accept=".csv", method="POST", url="http://127.0.0.1:8000/", @on(:uploaded, :uploaded), style="width:100%"),
+                # item([itemsection(p("Marker color")), itemsection(input(type="color", var"v-model"=:selected_color, label="Color"))]),
+                item(Genie.Renderer.Html.select(:selected_color_feature, clearable=true, options=:features, label="Color based on", useinput=true)),
+                item(Genie.Renderer.Html.select(:color_scale, options=:color_scale_options, label="Color Scale", useinput=true, @showif("selected_color_feature"))),
+                item(Genie.Renderer.Html.select(:selected_size_feature, clearable=true, options=:features, label="Size based on", useinput=true)),
+                item(Genie.Renderer.Html.select(:mapbox_style, options=:mapbox_styles, label="Mapbox Style", useinput=true)),
+                item(btn("Show Data", color="primary", icon="view_list", style="font-weight: 600; text-transform: none;", @click("data_show_dialog = true")), @showif("plot_data.lon.length > 0")),
+                item(btn("Choose Sample Data", color="primary", icon="grid_view", style="background-color: rgb(239,239,239); font-weight: 600; text-transform: none;", flat=true, @click("show_sample_data_dialog = true"))),
+                Html.div(class="q-pa-md q-gutter-sm", [
+                    StippleUI.dialog(:data_show_dialog, [
+                            card([
+                                Genie.Renderer.Html.table(title="View Data", :data_input; pagination=:data_pagination, style="height: 100%;")
+                            ])
+                        ], full__height=true, full__width=true)
+                ]),
+                Html.div(class="q-pa-md q-gutter-sm", [
+                    StippleUI.dialog(:show_sample_data_dialog, [
+                        card([
+                            card_section(
+                                quasar(:btn__toggle, v__model=:choosen_sample_data, options=:sample_data, style="flex-wrap: wrap")
+                            ),
+                            card_actions(
+                                [
+                                    btn("Close", color="primary", @click(:confirm_cancel_sample_data)),
+                                    btn("Show", color="primary", (disable!)="!choosen_sample_data", @click(:confirm_choose_sample_data))],
+                                align="right"
+                            )
+                        ])
+                    ])
+                ])
+            ]),
+            var"v-model"=:left_drawer_open, side="left", bordered=true, overlay=true
+        ),
+        page_container(
+            [
+            plot(:trace, layout=:layout, config=:config, configtype=ConfigType, class="window-height"),
+            Genie.Renderer.Html.div(
                 [
-                  btn("Close", color="primary", @click(:confirm_cancel_sample_data)),
-                  btn("Show", color="primary", (disable!)="!choosen_sample_data", @click(:confirm_choose_sample_data))],
-                align="right"
-              )
-            ])
-          ])
-        ])
-      ]),
-      var"v-model"=:left_drawer_open, side="left", bordered=true, overlay=true
-    ),
-    page_container(
-      [
-      plot(:trace, layout=:layout, config=:config, configtype=ConfigType, class="window-height"),
-      Genie.Renderer.Html.div(
-        [
-          itemsection(btn(; dense=true, flat=true, round=true, icon="arrow_right", @click(:animate)); avatar=true, @showif("!animate")),
-          itemsection(btn(; dense=true, flat=true, round=true, icon="pause", @click("animate = false")); avatar=true, @showif(:animate)),
-          itemsection(range("min_year":1:"max_year", :filter_range, label=true, color="blue", labelalways=true)),
-        ], style="position: fixed; bottom: 0; right: 0; padding: 12px 40px; background-color: transparent; width: 80%; display: flex; "),
-    ]
-    ),
-  ],
-  view="hHh lpR fFf",
-  class="window-height"
+                    itemsection(btn(; dense=true, flat=true, round=true, icon="arrow_right", @click(:animate)); avatar=true, @showif("!animate")),
+                    itemsection(btn(; dense=true, flat=true, round=true, icon="pause", @click("animate = false")); avatar=true, @showif(:animate)),
+                    itemsection(range("min_year":1:"max_year", :filter_range, label=true, color="blue", labelalways=true)),
+                ], style="position: fixed; bottom: 0; right: 0; padding: 12px 40px; background-color: transparent; width: 80%; display: flex; "),
+        ]
+        ),
+    ],
+    view="hHh lpR fFf",
+    class="window-height"
 )
 
 


### PR DESCRIPTION
We have pushed a fix for Stipple to enable mixins to work with unnamed models. Now we can remove the `Model` from the logic and use `@app` instead of `route`. This way, edits made to `ui.jl` are automatically loaded into the UI.

To run this, update GenieFramework to the latest commit
`
pkg> add GenieFramework#main
`